### PR TITLE
feat: add OpenGraph metadata for SNS sharing (#57)

### DIFF
--- a/app/games/cascade-blocks/layout.tsx
+++ b/app/games/cascade-blocks/layout.tsx
@@ -1,0 +1,34 @@
+import type { Metadata } from 'next';
+
+const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || 'https://gamehub-arcade.pages.dev';
+
+export const metadata: Metadata = {
+  title: 'Color Match Cascade - GameHub Arcade',
+  description: '같은 색 블록을 매치하고 연쇄 폭발을 터트리세요. 뿌요뿌요 스타일의 퍼즐 게임',
+  openGraph: {
+    title: 'Color Match Cascade - GameHub Arcade',
+    description: '같은 색 블록을 매치하고 연쇄 폭발을 터트리세요',
+    url: `${baseUrl}/games/cascade-blocks`,
+    siteName: 'GameHub Arcade',
+    images: [
+      {
+        url: `${baseUrl}/icon.svg`,
+        width: 512,
+        height: 512,
+        alt: 'Color Match Cascade - 퍼즐 게임',
+      },
+    ],
+    locale: 'ko_KR',
+    type: 'website',
+  },
+  twitter: {
+    card: 'summary',
+    title: 'Color Match Cascade - GameHub Arcade',
+    description: '같은 색 블록을 매치하고 연쇄 폭발을 터트리세요',
+    images: [`${baseUrl}/icon.svg`],
+  },
+};
+
+export default function CascadeBlocksLayout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/app/games/neon-serpent/layout.tsx
+++ b/app/games/neon-serpent/layout.tsx
@@ -1,0 +1,34 @@
+import type { Metadata } from 'next';
+
+const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || 'https://gamehub-arcade.pages.dev';
+
+export const metadata: Metadata = {
+  title: 'Neon Serpent - GameHub Arcade',
+  description: '절차적으로 변화하는 네온 필드를 누비며 성장하세요. 클래식 뱀 게임의 네온 아케이드 리메이크',
+  openGraph: {
+    title: 'Neon Serpent - GameHub Arcade',
+    description: '절차적으로 변화하는 네온 필드를 누비며 성장하세요',
+    url: `${baseUrl}/games/neon-serpent`,
+    siteName: 'GameHub Arcade',
+    images: [
+      {
+        url: `${baseUrl}/icon.svg`,
+        width: 512,
+        height: 512,
+        alt: 'Neon Serpent - 네온 아케이드 뱀 게임',
+      },
+    ],
+    locale: 'ko_KR',
+    type: 'website',
+  },
+  twitter: {
+    card: 'summary',
+    title: 'Neon Serpent - GameHub Arcade',
+    description: '절차적으로 변화하는 네온 필드를 누비며 성장하세요',
+    images: [`${baseUrl}/icon.svg`],
+  },
+};
+
+export default function NeonSerpentLayout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/app/games/photon-vanguard/layout.tsx
+++ b/app/games/photon-vanguard/layout.tsx
@@ -1,0 +1,34 @@
+import type { Metadata } from 'next';
+
+const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || 'https://gamehub-arcade.pages.dev';
+
+export const metadata: Metadata = {
+  title: 'Photon Vanguard - GameHub Arcade',
+  description: '360도 방향에서 밀려오는 적을 막아내세요. 방사형 타워 디펜스 슈팅 게임',
+  openGraph: {
+    title: 'Photon Vanguard - GameHub Arcade',
+    description: '360도 방향에서 밀려오는 적을 막아내세요',
+    url: `${baseUrl}/games/photon-vanguard`,
+    siteName: 'GameHub Arcade',
+    images: [
+      {
+        url: `${baseUrl}/icon.svg`,
+        width: 512,
+        height: 512,
+        alt: 'Photon Vanguard - 방사형 타워 디펜스 게임',
+      },
+    ],
+    locale: 'ko_KR',
+    type: 'website',
+  },
+  twitter: {
+    card: 'summary',
+    title: 'Photon Vanguard - GameHub Arcade',
+    description: '360도 방향에서 밀려오는 적을 막아내세요',
+    images: [`${baseUrl}/icon.svg`],
+  },
+};
+
+export default function PhotonVanguardLayout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/app/games/prism-smash/layout.tsx
+++ b/app/games/prism-smash/layout.tsx
@@ -1,0 +1,34 @@
+import type { Metadata } from 'next';
+
+const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || 'https://gamehub-arcade.pages.dev';
+
+export const metadata: Metadata = {
+  title: 'Prism Smash - GameHub Arcade',
+  description: '패들로 프리즘 볼을 반사시켜 벽돌을 파괴하세요. 레트로 브레이크아웃 게임',
+  openGraph: {
+    title: 'Prism Smash - GameHub Arcade',
+    description: '패들로 프리즘 볼을 반사시켜 벽돌을 파괴하세요',
+    url: `${baseUrl}/games/prism-smash`,
+    siteName: 'GameHub Arcade',
+    images: [
+      {
+        url: `${baseUrl}/icon.svg`,
+        width: 512,
+        height: 512,
+        alt: 'Prism Smash - 브레이크아웃 게임',
+      },
+    ],
+    locale: 'ko_KR',
+    type: 'website',
+  },
+  twitter: {
+    card: 'summary',
+    title: 'Prism Smash - GameHub Arcade',
+    description: '패들로 프리즘 볼을 반사시켜 벽돌을 파괴하세요',
+    images: [`${baseUrl}/icon.svg`],
+  },
+};
+
+export default function PrismSmashLayout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/app/games/pulse-paddles/layout.tsx
+++ b/app/games/pulse-paddles/layout.tsx
@@ -1,0 +1,34 @@
+import type { Metadata } from 'next';
+
+const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || 'https://gamehub-arcade.pages.dev';
+
+export const metadata: Metadata = {
+  title: 'Pulse Paddles - GameHub Arcade',
+  description: '네온 펄스 공을 주고받으며 대결하세요. 클래식 퐁 게임의 네온 리메이크',
+  openGraph: {
+    title: 'Pulse Paddles - GameHub Arcade',
+    description: '네온 펄스 공을 주고받으며 대결하세요',
+    url: `${baseUrl}/games/pulse-paddles`,
+    siteName: 'GameHub Arcade',
+    images: [
+      {
+        url: `${baseUrl}/icon.svg`,
+        width: 512,
+        height: 512,
+        alt: 'Pulse Paddles - 네온 퐁 게임',
+      },
+    ],
+    locale: 'ko_KR',
+    type: 'website',
+  },
+  twitter: {
+    card: 'summary',
+    title: 'Pulse Paddles - GameHub Arcade',
+    description: '네온 펄스 공을 주고받으며 대결하세요',
+    images: [`${baseUrl}/icon.svg`],
+  },
+};
+
+export default function PulsePaddlesLayout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/app/games/spectral-pursuit/layout.tsx
+++ b/app/games/spectral-pursuit/layout.tsx
@@ -1,0 +1,34 @@
+import type { Metadata } from 'next';
+
+const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || 'https://gamehub-arcade.pages.dev';
+
+export const metadata: Metadata = {
+  title: 'Spectral Pursuit - GameHub Arcade',
+  description: '스펙트럴 가디언을 피해 데이터 샤드를 수집하세요. 스텔스 체이스 아케이드 게임',
+  openGraph: {
+    title: 'Spectral Pursuit - GameHub Arcade',
+    description: '스펙트럴 가디언을 피해 데이터 샤드를 수집하세요',
+    url: `${baseUrl}/games/spectral-pursuit`,
+    siteName: 'GameHub Arcade',
+    images: [
+      {
+        url: `${baseUrl}/icon.svg`,
+        width: 512,
+        height: 512,
+        alt: 'Spectral Pursuit - 스텔스 체이스 게임',
+      },
+    ],
+    locale: 'ko_KR',
+    type: 'website',
+  },
+  twitter: {
+    card: 'summary',
+    title: 'Spectral Pursuit - GameHub Arcade',
+    description: '스펙트럴 가디언을 피해 데이터 샤드를 수집하세요',
+    images: [`${baseUrl}/icon.svg`],
+  },
+};
+
+export default function SpectralPursuitLayout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/app/games/starshard-drift/layout.tsx
+++ b/app/games/starshard-drift/layout.tsx
@@ -1,0 +1,34 @@
+import type { Metadata } from 'next';
+
+const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || 'https://gamehub-arcade.pages.dev';
+
+export const metadata: Metadata = {
+  title: 'Starshard Drift - GameHub Arcade',
+  description: '중력장을 헤치고 스타샤드를 수집하세요. 물리 기반 중력 미션 게임',
+  openGraph: {
+    title: 'Starshard Drift - GameHub Arcade',
+    description: '중력장을 헤치고 스타샤드를 수집하세요',
+    url: `${baseUrl}/games/starshard-drift`,
+    siteName: 'GameHub Arcade',
+    images: [
+      {
+        url: `${baseUrl}/icon.svg`,
+        width: 512,
+        height: 512,
+        alt: 'Starshard Drift - 중력 미션 게임',
+      },
+    ],
+    locale: 'ko_KR',
+    type: 'website',
+  },
+  twitter: {
+    card: 'summary',
+    title: 'Starshard Drift - GameHub Arcade',
+    description: '중력장을 헤치고 스타샤드를 수집하세요',
+    images: [`${baseUrl}/icon.svg`],
+  },
+};
+
+export default function StarshardDriftLayout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/app/games/stellar-salvo/layout.tsx
+++ b/app/games/stellar-salvo/layout.tsx
@@ -1,0 +1,34 @@
+import type { Metadata } from 'next';
+
+const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || 'https://gamehub-arcade.pages.dev';
+
+export const metadata: Metadata = {
+  title: 'Stellar Salvo - GameHub Arcade',
+  description: '절차적으로 진화하는 VOID WRAITH 편대와 맞서 살아남으세요. 레트로 아케이드 슈팅 게임',
+  openGraph: {
+    title: 'Stellar Salvo - GameHub Arcade',
+    description: '절차적으로 진화하는 VOID WRAITH 편대와 맞서 살아남으세요',
+    url: `${baseUrl}/games/stellar-salvo`,
+    siteName: 'GameHub Arcade',
+    images: [
+      {
+        url: `${baseUrl}/icon.svg`,
+        width: 512,
+        height: 512,
+        alt: 'Stellar Salvo - 레트로 아케이드 슈팅 게임',
+      },
+    ],
+    locale: 'ko_KR',
+    type: 'website',
+  },
+  twitter: {
+    card: 'summary',
+    title: 'Stellar Salvo - GameHub Arcade',
+    description: '절차적으로 진화하는 VOID WRAITH 편대와 맞서 살아남으세요',
+    images: [`${baseUrl}/icon.svg`],
+  },
+};
+
+export default function StellarSalvoLayout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/components/share/ShareModal.tsx
+++ b/components/share/ShareModal.tsx
@@ -53,7 +53,13 @@ export function ShareModal({ shareData, isOpen, onClose }: ShareModalProps) {
   };
 
   const handleKakaoShare = () => {
-    shareToKakao({ url: shareData.url, title, text: message });
+    shareToKakao({
+      url: shareData.url,
+      title,
+      text: message,
+      gameId: shareData.gameId,
+      score: shareData.score,
+    });
   };
 
   const handleWebShare = async () => {

--- a/lib/share/platforms.ts
+++ b/lib/share/platforms.ts
@@ -11,6 +11,8 @@ export interface ShareUrlParams {
   title: string;
   text: string;
   hashtags?: string[];
+  gameId?: string;
+  score?: number;
 }
 
 /**
@@ -54,13 +56,17 @@ export function shareToKakao(params: ShareUrlParams): void {
   }
 
   const { url, title, text } = params;
+  // TODO: gameId, score를 활용한 커스텀 OG 이미지 생성 예정
+
+  // 아이콘 이미지 사용 (임시)
+  const ogImageUrl = `${window.location.origin}/icon.svg`;
 
   window.Kakao.Share.sendDefault({
     objectType: 'feed',
     content: {
       title,
       description: text,
-      imageUrl: `${window.location.origin}/og-image.png`, // Open Graph 이미지
+      imageUrl: ogImageUrl,
       link: {
         mobileWebUrl: url,
         webUrl: url,

--- a/public/og/README.md
+++ b/public/og/README.md
@@ -1,0 +1,91 @@
+# Open Graph Images
+
+## 디렉토리 구조
+
+```
+og/
+├── default.png          # 기본 OG 이미지 (1200x630px)
+└── games/
+    ├── stellar-salvo.png
+    ├── neon-serpent.png
+    ├── cascade-blocks.png
+    ├── prism-smash.png
+    ├── pulse-paddles.png
+    ├── photon-vanguard.png
+    ├── spectral-pursuit.png
+    └── starshard-drift.png
+```
+
+## 디자인 사양
+
+### 이미지 크기
+- **1200x630px** (Facebook, Twitter 권장)
+- **PNG 포맷**
+- **파일 크기 < 5MB**
+
+### 디자인 요소
+
+각 게임 이미지는 다음 요소를 포함해야 합니다:
+
+1. **배경**: 네온 그라디언트
+   ```css
+   background: linear-gradient(135deg, #1a0033 0%, #000000 50%, #001a33 100%);
+   ```
+
+2. **그리드 패턴**: 레트로 스타일
+   - 라인 색상: `rgba(0, 240, 255, 0.1)`
+   - 그리드 간격: 50px
+
+3. **게임 아이콘**: 중앙 배치, 큰 사이즈 (160px)
+   - Stellar Salvo: 🚀 (cyan glow)
+   - Neon Serpent: 🐍 (green glow)
+   - Cascade Blocks: 🎮 (pink glow)
+   - Prism Smash: 🔨 (yellow glow)
+   - Pulse Paddles: 🏓 (cyan glow)
+   - Photon Vanguard: 🛡️ (pink glow)
+   - Spectral Pursuit: 👻 (purple glow)
+   - Starshard Drift: 💎 (cyan glow)
+
+4. **게임명**: Pixel 폰트, 게임별 네온 컬러
+   - 크기: 72px
+   - 텍스트 쉐도우: `0 0 30px {color}`
+
+5. **GameHub 로고**: 하단 중앙
+   - 텍스트: "🎮 GameHub Arcade"
+   - 색상: #ff10f0 (pink)
+   - 크기: 32px
+
+6. **하단 네온 라인**: 게임별 컬러
+   - 높이: 4px
+   - 그라데이션 + 글로우 효과
+
+## 게임별 컬러
+
+| 게임 | 메인 컬러 | 컬러 코드 |
+|------|-----------|-----------|
+| Stellar Salvo | Cyan | #00f0ff |
+| Neon Serpent | Green | #00ff00 |
+| Cascade Blocks | Pink | #ff10f0 |
+| Prism Smash | Yellow | #ffff00 |
+| Pulse Paddles | Cyan | #00f0ff |
+| Photon Vanguard | Pink | #ff10f0 |
+| Spectral Pursuit | Purple | #9d00ff |
+| Starshard Drift | Cyan | #00f0ff |
+
+## 생성 도구
+
+이미지는 다음 도구로 생성할 수 있습니다:
+
+1. **Figma** - 디자인 템플릿 사용
+2. **Canva** - OG 이미지 템플릿
+3. **HTML2Canvas** - 프로그래매틱 생성
+4. **ImageMagick** - 커맨드라인 도구
+
+## 임시 대체 방안
+
+이미지가 준비될 때까지 metadata에서 기본 이미지 사용:
+```typescript
+openGraph: {
+  images: ['/icon.svg'], // 임시로 아이콘 사용
+}
+```


### PR DESCRIPTION
## Summary
게임별 SNS 공유 시 사용할 OpenGraph 메타데이터 완성.
8개 모든 게임에 대한 OG metadata 설정 완료.

## Changes

### OpenGraph Metadata
- ✨ **All 8 games**: 게임별 layout.tsx with OG metadata
- 🎮 **Stellar Salvo**: 절차적 진화 슈팅 게임
- 🐍 **Neon Serpent**: 네온 필드 뱀 게임
- 🔷 **Color Match Cascade**: 뿌요뿌요 스타일 퍼즐
- 🧊 **Prism Smash**: 브레이크아웃 게임
- 🏓 **Pulse Paddles**: 네온 퐁 게임
- 🛡️ **Photon Vanguard**: 방사형 타워 디펜스
- 🔮 **Spectral Pursuit**: 스텔스 체이스 게임
- 💎 **Starshard Drift**: 중력 미션 게임

### Technical Implementation
- 📝 Created `public/og/README.md` with OG image specifications
- 🔧 Updated `ShareUrlParams` to include gameId and score
- 🎨 Using icon.svg as temporary fallback image
- 📱 Twitter card: 'summary' format for icon compatibility
- ⚙️ Next.js static export compatible (no API routes)

## Design Specifications

### OG Image Specs (Future)
- **Size**: 1200x630px PNG format
- **Design**: Neon arcade theme with game-specific colors
- **Elements**: 
  - Gradient background (#1a0033 → #000000 → #001a33)
  - Grid pattern overlay
  - Game icon (160px) with glow effect
  - Game title (72px pixel font)
  - GameHub logo
  - Bottom neon line with game color

### Game Colors
| Game | Color | Code |
|------|-------|------|
| Stellar Salvo | Cyan | #00f0ff |
| Neon Serpent | Green | #00ff00 |
| Color Match Cascade | Pink | #ff10f0 |
| Prism Smash | Yellow | #ffff00 |
| Pulse Paddles | Cyan | #00f0ff |
| Photon Vanguard | Pink | #ff10f0 |
| Spectral Pursuit | Purple | #9d00ff |
| Starshard Drift | Cyan | #00f0ff |

## Testing
- ✅ Build test passed (npm run build)
- ✅ All 8 games have proper metadata
- ✅ No ESLint/TypeScript errors
- ✅ Static export compatible

## Next Steps
- [ ] Create 8 game-specific OG images (1200x630px)
- [ ] Use design tools (Figma/Canva/HTML2Canvas)
- [ ] Replace icon.svg with proper OG images in metadata
- [ ] Test SNS share preview (Twitter, Facebook, Kakao)

## Screenshots
현재는 임시로 icon.svg를 사용중이며, 추후 게임별 커스텀 OG 이미지로 교체 예정입니다.

## Related Issue
Closes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)