### PR TITLE
feat: 키보드 단축키 가이드 (#64)

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -7,6 +7,7 @@ import Footer from "@/components/layout/Footer";
 import { I18nProvider } from "@/lib/i18n/provider";
 import { StructuredData } from "./structured-data";
 import ServiceWorkerRegistration from "@/components/pwa/ServiceWorkerRegistration";
+import { ShortcutsProvider } from "@/components/shortcuts/ShortcutsProvider";
 
 const inter = Inter({
   subsets: ["latin"],
@@ -115,12 +116,14 @@ export default function RootLayout({
       </head>
       <body className={`${inter.className} antialiased flex flex-col min-h-screen`}>
         <I18nProvider>
-          <Navbar />
-          <div className="flex-1 pt-16">
-            {children}
-          </div>
-          <Footer />
-          <ServiceWorkerRegistration />
+          <ShortcutsProvider>
+            <Navbar />
+            <div className="flex-1 pt-16">
+              {children}
+            </div>
+            <Footer />
+            <ServiceWorkerRegistration />
+          </ShortcutsProvider>
         </I18nProvider>
       </body>
     </html>

--- a/components/layout/Navbar.tsx
+++ b/components/layout/Navbar.tsx
@@ -7,6 +7,13 @@ import { useI18n } from '@/lib/i18n/provider';
 
 export default function Navbar() {
   const { t } = useI18n();
+
+  const handleShortcutsClick = () => {
+    // Trigger '?' key event to open shortcuts modal
+    const event = new KeyboardEvent('keydown', { key: '?' });
+    window.dispatchEvent(event);
+  };
+
   return (
     <nav className="fixed top-0 left-0 right-0 z-50 bg-black/80 backdrop-blur-sm border-b border-neon-cyan/30">
       <div className="container mx-auto px-4">
@@ -45,6 +52,16 @@ export default function Navbar() {
               {t.common.about}
             </Link>
 
+            {/* Keyboard Shortcuts */}
+            <button
+              onClick={handleShortcutsClick}
+              className="text-bright hover:text-bright-cyan transition-colors duration-300"
+              title={t.common.keyboardShortcuts || '키보드 단축키'}
+              aria-label={t.common.keyboardShortcuts || '키보드 단축키'}
+            >
+              <span className="text-lg">⌨️</span>
+            </button>
+
             {/* Audio Settings */}
             <AudioSettings />
 
@@ -52,8 +69,16 @@ export default function Navbar() {
             <LanguageSwitcher />
           </div>
 
-          {/* Mobile: Audio Settings + Language Switcher + Menu Button */}
+          {/* Mobile: Keyboard Shortcuts + Audio Settings + Language Switcher + Menu Button */}
           <div className="md:hidden flex items-center space-x-4">
+            <button
+              onClick={handleShortcutsClick}
+              className="text-bright hover:text-bright-cyan transition-colors duration-300"
+              title={t.common.keyboardShortcuts || '키보드 단축키'}
+              aria-label={t.common.keyboardShortcuts || '키보드 단축키'}
+            >
+              <span className="text-lg">⌨️</span>
+            </button>
             <AudioSettings />
             <LanguageSwitcher />
             <button className="text-neon-cyan hover:text-neon-pink transition-colors">

--- a/components/shortcuts/KeyboardShortcutsHelp.tsx
+++ b/components/shortcuts/KeyboardShortcutsHelp.tsx
@@ -1,0 +1,172 @@
+/**
+ * KeyboardShortcutsHelp Component
+ * 키보드 단축키 가이드 모달
+ */
+
+'use client';
+
+import { useEffect } from 'react';
+import { shortcutGroups } from '@/lib/shortcuts/data';
+import type { KeyboardShortcut, ModifierKey } from '@/lib/shortcuts/types';
+
+interface KeyboardShortcutsHelpProps {
+  isOpen: boolean;
+  onClose: () => void;
+  language?: 'ko' | 'en';
+}
+
+export function KeyboardShortcutsHelp({ isOpen, onClose, language = 'ko' }: KeyboardShortcutsHelpProps) {
+  // Esc 키로 닫기
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        onClose();
+      }
+    };
+
+    window.addEventListener('keydown', handleEscape);
+    return () => window.removeEventListener('keydown', handleEscape);
+  }, [isOpen, onClose]);
+
+  // 모달이 열릴 때 body 스크롤 방지
+  useEffect(() => {
+    if (isOpen) {
+      document.body.style.overflow = 'hidden';
+    } else {
+      document.body.style.overflow = '';
+    }
+
+    return () => {
+      document.body.style.overflow = '';
+    };
+  }, [isOpen]);
+
+  if (!isOpen) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/80 backdrop-blur-sm animate-fade-in"
+      onClick={onClose}
+    >
+      <div
+        className="relative w-full max-w-4xl max-h-[90vh] overflow-y-auto bg-black border-2 border-bright-cyan rounded-xl shadow-[0_0_30px_rgba(0,240,255,0.5)] m-4"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="sticky top-0 bg-black border-b border-bright-cyan/30 px-6 py-4 flex items-center justify-between z-10">
+          <div>
+            <h2 className="pixel-text text-2xl text-bright-cyan mb-1">
+              {language === 'ko' ? '⌨️ 키보드 단축키' : '⌨️ Keyboard Shortcuts'}
+            </h2>
+            <p className="text-xs text-gray-400">
+              {language === 'ko'
+                ? '게임을 더 빠르게 플레이하고 탐색하세요'
+                : 'Play games and navigate faster'}
+            </p>
+          </div>
+          <button
+            onClick={onClose}
+            className="px-4 py-2 border border-bright-cyan/60 text-bright-cyan rounded hover:bg-bright-cyan/10 transition-all duration-300 text-sm pixel-text"
+            aria-label="Close"
+          >
+            ✕
+          </button>
+        </div>
+
+        {/* Content */}
+        <div className="p-6 space-y-8">
+          {shortcutGroups.map((group) => (
+            <div key={group.category}>
+              <h3 className="pixel-text text-lg text-bright-yellow mb-4 border-b border-bright-yellow/30 pb-2">
+                {language === 'ko' ? group.titleKo : group.title}
+              </h3>
+
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                {group.shortcuts.map((shortcut) => (
+                  <ShortcutItem key={shortcut.id} shortcut={shortcut} language={language} />
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+
+        {/* Footer */}
+        <div className="sticky bottom-0 bg-black border-t border-bright-cyan/30 px-6 py-4 text-center">
+          <p className="text-xs text-gray-400">
+            {language === 'ko' ? (
+              <>
+                <kbd className="kbd">?</kbd> 키를 눌러 이 가이드를 다시 열 수 있습니다
+              </>
+            ) : (
+              <>
+                Press <kbd className="kbd">?</kbd> to open this guide again
+              </>
+            )}
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * 개별 단축키 항목 컴포넌트
+ */
+function ShortcutItem({ shortcut, language }: { shortcut: KeyboardShortcut; language: 'ko' | 'en' }) {
+  return (
+    <div className="flex items-center justify-between bg-black/40 border border-bright-cyan/20 rounded-lg p-3 hover:border-bright-cyan/60 hover:shadow-[0_0_15px_rgba(0,240,255,0.3)] transition-all duration-300">
+      <div className="flex items-center gap-3">
+        {shortcut.icon && <span className="text-2xl">{shortcut.icon}</span>}
+        <span className="text-sm text-gray-300">
+          {language === 'ko' ? shortcut.descriptionKo || shortcut.description : shortcut.description}
+        </span>
+      </div>
+
+      <div className="flex items-center gap-2">
+        {shortcut.modifiers?.map((modifier) => (
+          <KeyBadge key={modifier} text={getModifierLabel(modifier)} />
+        ))}
+        <KeyBadge text={shortcut.key} isPrimary />
+      </div>
+    </div>
+  );
+}
+
+/**
+ * 키보드 키 배지 컴포넌트
+ */
+function KeyBadge({ text, isPrimary = false }: { text: string; isPrimary?: boolean }) {
+  return (
+    <kbd
+      className={`kbd px-3 py-1 text-xs font-bold rounded shadow-md ${
+        isPrimary
+          ? 'bg-bright-cyan/20 border-2 border-bright-cyan text-bright-cyan shadow-[0_0_10px_rgba(0,240,255,0.5)]'
+          : 'bg-gray-800 border border-gray-600 text-gray-300'
+      }`}
+    >
+      {text}
+    </kbd>
+  );
+}
+
+/**
+ * 수정자 키 라벨 가져오기
+ */
+function getModifierLabel(modifier: ModifierKey): string {
+  const isMac = typeof navigator !== 'undefined' && navigator.platform.toUpperCase().indexOf('MAC') >= 0;
+
+  switch (modifier) {
+    case 'ctrl':
+      return isMac ? '⌃' : 'Ctrl';
+    case 'shift':
+      return isMac ? '⇧' : 'Shift';
+    case 'alt':
+      return isMac ? '⌥' : 'Alt';
+    case 'meta':
+      return isMac ? '⌘' : 'Win';
+    default:
+      return modifier;
+  }
+}

--- a/components/shortcuts/ShortcutsProvider.tsx
+++ b/components/shortcuts/ShortcutsProvider.tsx
@@ -1,0 +1,73 @@
+/**
+ * ShortcutsProvider Component
+ * 전역 키보드 단축키 핸들러 및 모달 관리
+ */
+
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import { useRouter } from 'next/navigation';
+import { KeyboardShortcutsHelp } from './KeyboardShortcutsHelp';
+import { useI18n } from '@/lib/i18n/provider';
+
+export function ShortcutsProvider({ children }: { children: React.ReactNode }) {
+  const [isHelpOpen, setIsHelpOpen] = useState(false);
+  const router = useRouter();
+  const { locale } = useI18n();
+
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      // input/textarea에서는 단축키 비활성화
+      const target = e.target as HTMLElement;
+      if (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable) {
+        return;
+      }
+
+      // ? 키: 도움말 열기/닫기
+      if (e.key === '?' && !e.ctrlKey && !e.metaKey && !e.altKey) {
+        e.preventDefault();
+        setIsHelpOpen((prev) => !prev);
+        return;
+      }
+
+      // Shift + 키 네비게이션
+      if (e.shiftKey && !e.ctrlKey && !e.metaKey && !e.altKey) {
+        switch (e.key.toUpperCase()) {
+          case 'H':
+            e.preventDefault();
+            router.push('/');
+            break;
+          case 'G':
+            e.preventDefault();
+            router.push('/games');
+            break;
+          case 'L':
+            e.preventDefault();
+            router.push('/leaderboard');
+            break;
+          case 'A':
+            e.preventDefault();
+            router.push('/achievements');
+            break;
+          case 'I':
+            e.preventDefault();
+            router.push('/about');
+            break;
+        }
+      }
+    },
+    [router]
+  );
+
+  useEffect(() => {
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [handleKeyDown]);
+
+  return (
+    <>
+      {children}
+      <KeyboardShortcutsHelp isOpen={isHelpOpen} onClose={() => setIsHelpOpen(false)} language={locale} />
+    </>
+  );
+}

--- a/lib/i18n/locales/en.ts
+++ b/lib/i18n/locales/en.ts
@@ -17,6 +17,7 @@ export const en: Translations = {
     connect: 'Connect',
     openSource: 'Open Source Project',
     close: 'Close',
+    keyboardShortcuts: 'Keyboard Shortcuts',
   },
 
   // Audio Settings

--- a/lib/i18n/locales/ko.ts
+++ b/lib/i18n/locales/ko.ts
@@ -15,6 +15,7 @@ export const ko = {
     connect: 'Connect',
     openSource: 'Open Source Project',
     close: '닫기',
+    keyboardShortcuts: '키보드 단축키',
   },
 
   // Audio Settings

--- a/lib/shortcuts/data.ts
+++ b/lib/shortcuts/data.ts
@@ -1,0 +1,153 @@
+/**
+ * Keyboard Shortcuts Data
+ * 키보드 단축키 데이터 정의
+ */
+
+import type { ShortcutGroup } from './types';
+
+export const shortcutGroups: ShortcutGroup[] = [
+  {
+    category: 'global',
+    title: 'Global Shortcuts',
+    titleKo: '전역 단축키',
+    shortcuts: [
+      {
+        id: 'help',
+        category: 'global',
+        key: '?',
+        description: 'Open keyboard shortcuts guide',
+        descriptionKo: '키보드 단축키 가이드 열기',
+        icon: '❓',
+      },
+      {
+        id: 'search',
+        category: 'global',
+        key: '/',
+        description: 'Focus search (on games page)',
+        descriptionKo: '검색 포커스 (게임 목록 페이지)',
+        icon: '🔍',
+      },
+      {
+        id: 'escape',
+        category: 'global',
+        key: 'Esc',
+        description: 'Close modal or dialog',
+        descriptionKo: '모달 또는 대화상자 닫기',
+        icon: '❌',
+      },
+    ],
+  },
+  {
+    category: 'navigation',
+    title: 'Navigation',
+    titleKo: '네비게이션',
+    shortcuts: [
+      {
+        id: 'nav-home',
+        category: 'navigation',
+        key: 'H',
+        modifiers: ['shift'],
+        description: 'Go to Home',
+        descriptionKo: '홈으로 이동',
+        icon: '🏠',
+      },
+      {
+        id: 'nav-games',
+        category: 'navigation',
+        key: 'G',
+        modifiers: ['shift'],
+        description: 'Go to Games List',
+        descriptionKo: '게임 목록으로 이동',
+        icon: '🎮',
+      },
+      {
+        id: 'nav-leaderboard',
+        category: 'navigation',
+        key: 'L',
+        modifiers: ['shift'],
+        description: 'Go to Leaderboard',
+        descriptionKo: '리더보드로 이동',
+        icon: '🏆',
+      },
+      {
+        id: 'nav-achievements',
+        category: 'navigation',
+        key: 'A',
+        modifiers: ['shift'],
+        description: 'Go to Achievements',
+        descriptionKo: '업적으로 이동',
+        icon: '🎖️',
+      },
+      {
+        id: 'nav-about',
+        category: 'navigation',
+        key: 'I',
+        modifiers: ['shift'],
+        description: 'Go to About',
+        descriptionKo: '소개 페이지로 이동',
+        icon: 'ℹ️',
+      },
+    ],
+  },
+  {
+    category: 'game',
+    title: 'In-Game Controls',
+    titleKo: '게임 조작',
+    shortcuts: [
+      {
+        id: 'game-pause',
+        category: 'game',
+        key: 'Space',
+        description: 'Pause / Resume game',
+        descriptionKo: '게임 일시정지 / 재개',
+        icon: '⏸️',
+      },
+      {
+        id: 'game-restart',
+        category: 'game',
+        key: 'R',
+        description: 'Restart game',
+        descriptionKo: '게임 재시작',
+        icon: '🔄',
+      },
+      {
+        id: 'game-mute',
+        category: 'game',
+        key: 'M',
+        description: 'Mute / Unmute sound',
+        descriptionKo: '음소거 / 음소거 해제',
+        icon: '🔇',
+      },
+      {
+        id: 'game-move',
+        category: 'game',
+        key: '← → ↑ ↓',
+        description: 'Move player',
+        descriptionKo: '플레이어 이동',
+        icon: '🕹️',
+      },
+      {
+        id: 'game-action',
+        category: 'game',
+        key: 'Shift',
+        description: 'Action (dash, shoot, etc.)',
+        descriptionKo: '액션 (대시, 발사 등)',
+        icon: '⚡',
+      },
+    ],
+  },
+];
+
+/**
+ * 카테고리별 단축키 조회
+ */
+export function getShortcutsByCategory(category: 'global' | 'game' | 'navigation') {
+  return shortcutGroups.find((group) => group.category === category);
+}
+
+/**
+ * 모든 단축키 조회
+ */
+export function getAllShortcuts() {
+  return shortcutGroups.flatMap((group) => group.shortcuts);
+}

--- a/lib/shortcuts/types.ts
+++ b/lib/shortcuts/types.ts
@@ -1,0 +1,24 @@
+/**
+ * Keyboard Shortcuts Types
+ * 키보드 단축키 타입 정의
+ */
+
+export type ShortcutCategory = 'global' | 'game' | 'navigation';
+export type ModifierKey = 'ctrl' | 'shift' | 'alt' | 'meta';
+
+export interface KeyboardShortcut {
+  id: string;
+  category: ShortcutCategory;
+  key: string; // 주 키 (예: 'Space', '/', '?')
+  modifiers?: ModifierKey[]; // 수정자 키 (Ctrl, Shift 등)
+  description: string;
+  icon?: string; // 이모지 아이콘
+  descriptionKo?: string; // 한국어 설명
+}
+
+export interface ShortcutGroup {
+  category: ShortcutCategory;
+  title: string;
+  titleKo: string;
+  shortcuts: KeyboardShortcut[];
+}


### PR DESCRIPTION
## Summary
키보드 단축키 시스템 전체를 구현했습니다. 사용자가 `?` 키를 눌러 단축키 가이드를 확인하거나 `Shift+key` 조합으로 빠르게 네비게이션할 수 있습니다.

## 주요 구현 사항

### 1. 데이터 구조
- **types.ts**: 단축키 타입 정의 (ShortcutCategory, ModifierKey, KeyboardShortcut)
- **data.ts**: 단축키 데이터 (Global, Navigation, In-Game Controls)

### 2. UI 컴포넌트
- **KeyboardShortcutsHelp 모달**
  - Full-screen 오버레이, 네온 시안 테두리
  - 카테고리별 단축키 그룹핑 (3개 카테고리)
  - 플랫폼별 키 표시 (Mac ⌘/⇧ vs Windows Ctrl/Shift)
  - Esc 키로 닫기, Click outside to close
  - Body scroll 방지

### 3. 글로벌 키보드 핸들러
- **ShortcutsProvider**
  - `?` 키: 단축키 가이드 토글
  - `Shift+H`: 홈 (/)
  - `Shift+G`: 게임 목록 (/games)
  - `Shift+L`: 리더보드 (/leaderboard)
  - `Shift+A`: 업적 (/achievements)
  - `Shift+I`: 소개 (/about)
  - Input/textarea 필드에서 단축키 비활성화

### 4. Navbar 통합
- ⌨️ 아이콘 버튼 추가 (Desktop + Mobile)
- 클릭 시 `?` 키 이벤트 트리거하여 모달 열기

### 5. i18n 지원
- 한국어/영어 번역 추가
- 단축키 설명 이중 언어 지원

## 기술 특징
- **Client-side Provider Pattern**: 전역 키보드 이벤트 관리
- **React Hooks**: useState, useEffect, useCallback
- **Next.js Router**: router.push()로 네비게이션
- **Platform Detection**: navigator.platform으로 Mac/Windows 감지
- **Accessibility**: ARIA labels, semantic HTML

## 파일 구조
```
lib/shortcuts/
  ├── types.ts          # 타입 정의
  └── data.ts           # 단축키 데이터

components/shortcuts/
  ├── KeyboardShortcutsHelp.tsx  # 모달 UI
  └── ShortcutsProvider.tsx      # 글로벌 핸들러
```

## 테스트 시나리오
1. **모달 열기**
   - Navbar ⌨️ 버튼 클릭
   - 키보드 `?` 키 입력
   → 단축키 가이드 모달 표시

2. **모달 닫기**
   - `Esc` 키
   - 닫기 버튼 (✕)
   - 모달 외부 클릭

3. **네비게이션 단축키**
   - `Shift+H`: 홈 페이지 이동 확인
   - `Shift+G`: 게임 목록 이동 확인
   - `Shift+L`: 리더보드 이동 확인
   - `Shift+A`: 업적 페이지 이동 확인
   - `Shift+I`: 소개 페이지 이동 확인

4. **입력 필드 제외**
   - input/textarea 포커스 상태에서 단축키 비활성화 확인

## 개발 환경
- **Dev Server**: http://localhost:3003
- **Build**: ✅ 성공 (경고 해결 완료)

## Related Issue
Closes #64

## Screenshots
### 모달 전체 화면
![Keyboard Shortcuts Modal](https://via.placeholder.com/800x600?text=Keyboard+Shortcuts+Modal)

### Navbar 버튼
![Navbar Button](https://via.placeholder.com/400x100?text=Navbar+Keyboard+Button)

🤖 Generated with [Claude Code](https://claude.com/claude-code)